### PR TITLE
Panic Prevention + minor constant refactor(s)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -10,6 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - uses: Jerome1337/gofmt-action@v1.0.4
 
   govet:
@@ -17,6 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - run: |
           go vet ./...
 
@@ -25,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -38,5 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.16"
       - run: |
           go test ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.4 as build
+FROM registry.access.redhat.com/ubi8/ubi:8.5 as build
 
 RUN mkdir /build
 WORKDIR /build

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func listInternalSources(limit, offset int64) *SourceResponse {
 		"x-rh-sources-psk":            {psk},
 	}}
 	resp, err := httpClient.Do(req)
-	if err != nil || resp.StatusCode != 200 {
+	if err != nil || (resp != nil && resp.StatusCode != 200) {
 		log.Fatalf("Failed to list internal sources: %v", err)
 	}
 	defer resp.Body.Close()
@@ -108,7 +108,7 @@ func checkAvailability(id, tenant string) {
 		"x-rh-sources-psk":            {psk},
 	}}
 	resp, err := httpClient.Do(req)
-	if err != nil || resp.StatusCode != 202 {
+	if err != nil || (resp != nil && resp.StatusCode != 202) {
 		log.Printf("Failed to request availability for [tenant %v], [source %v]", tenant, id)
 		if resp != nil {
 			log.Printf("Request status code: %v", resp.StatusCode)

--- a/main.go
+++ b/main.go
@@ -77,12 +77,12 @@ func listInternalSources(limit, offset int64) *SourceResponse {
 	log.Printf("Requesting [limit %v] + [offset %v] sources from internal API at [%v]", limit, offset, host)
 
 	url, _ := url.Parse(fmt.Sprintf("%v/internal/v2.0/sources?limit=%v&offset=%v", host, limit, offset))
-	req := &http.Request{Method: "GET", URL: url, Header: map[string][]string{
+	req := &http.Request{Method: http.MethodGet, URL: url, Header: map[string][]string{
 		"x-rh-sources-account-number": {"sources_monitor"},
 		"x-rh-sources-psk":            {psk},
 	}}
 	resp, err := httpClient.Do(req)
-	if err != nil || (resp != nil && resp.StatusCode != 200) {
+	if err != nil || (resp != nil && resp.StatusCode != http.StatusOK) {
 		log.Fatalf("Failed to list internal sources: %v", err)
 	}
 	defer resp.Body.Close()
@@ -103,12 +103,12 @@ func checkAvailability(id, tenant string) {
 	log.Printf("Requesting availability status for [tenant %v], [source %v]", tenant, id)
 
 	url, _ := url.Parse(fmt.Sprintf("%v/api/sources/v3.1/sources/%v/check_availability", host, id))
-	req := &http.Request{Method: "POST", URL: url, Header: map[string][]string{
+	req := &http.Request{Method: http.MethodPost, URL: url, Header: map[string][]string{
 		"x-rh-sources-account-number": {tenant},
 		"x-rh-sources-psk":            {psk},
 	}}
 	resp, err := httpClient.Do(req)
-	if err != nil || (resp != nil && resp.StatusCode != 202) {
+	if err != nil || (resp != nil && resp.StatusCode != http.StatusAccepted) {
 		log.Printf("Failed to request availability for [tenant %v], [source %v]", tenant, id)
 		if resp != nil {
 			log.Printf("Request status code: %v", resp.StatusCode)

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"
@@ -87,7 +87,7 @@ func listInternalSources(limit, offset int64) *SourceResponse {
 	}
 	defer resp.Body.Close()
 
-	data, _ := ioutil.ReadAll(resp.Body)
+	data, _ := io.ReadAll(resp.Body)
 	sources := &SourceResponse{}
 	err = json.Unmarshal(data, sources)
 	if err != nil {


### PR DESCRIPTION
Few things, I noticed a couple errors on our availbilty checkers where it would panic due to a null pointer - thinking it was because of my checking `resp.StatusCode` when an error would occur and resp *MIGHT* be nil.

Also switched out the `"GET"` and `"POST"` settings for the constants in net/http.

EDIT: Ended up switching out for ubi 8.5 to get golang security updates, which also ended up with me having to update the github workflows to use go 1.16.