### PR TITLE
Random Deployment Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.5 as build
-
-RUN mkdir /build
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as build
 WORKDIR /build
 
-RUN dnf -y --disableplugin=subscription-manager install go
+RUN microdnf install go
 
 COPY go.mod .
 RUN go mod download

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -73,10 +73,14 @@ objects:
             cpu: ${CPU_REQUEST}
             memory: ${MEMORY_REQUEST}
 parameters:
-- name: CPU_LIMIT
-  value: 250m
 - name: CPU_REQUEST
-  value: 50m
+  value: 75m
+- name: CPU_LIMIT
+  value: 150m
+- name: MEMORY_REQUEST
+  value: 50Mi
+- name: MEMORY_LIMIT
+  value: 100Mi
 - description: Clowder ENV
   name: ENV_NAME
   required: true
@@ -86,10 +90,6 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
-- name: MEMORY_LIMIT
-  value: 100Mi
-- name: MEMORY_REQUEST
-  value: 25Mi
 - description: Schedule for Sources with available status
   displayName: Schedule for Available Sources
   name: SCHEDULE_AVAILABLE


### PR DESCRIPTION
Just a few things:
1. Changing the image tag to `:latest` per security's recommendations. That way we get security updates automaticlaly. We can just `:latest` since RH re-tags latest with the latest release.
2. Use `ubi-minimal` since it is a smaller/faster image for this.
3. Change the resource request/limits to be a ratio of 2 to make clowder happy, per this slack thread: https://coreos.slack.com/archives/C0246P60U8H/p1642535164001900

