### PR TITLE
[RHCLOUD-18924] chore: force rebuild of repository to apply the latest security patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# This comment inteds to force a rebuild with the latest image to fulfill the
+# request from the security team to apply the latest patches.
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest as build
 WORKDIR /build
 


### PR DESCRIPTION
The security team has requested to force a rebuild so that the latest
security patches get applied to the running images in the different
environments.

## Links

[[RHCLOUD-18924]](https://issues.redhat.com/browse/RHCLOUD-18924)