### PR TITLE
[RHCLOUD-19948] feature: check "in_progress" sources too

### DIFF
--- a/main.go
+++ b/main.go
@@ -138,10 +138,10 @@ func checkAvailability(id, tenant, orgId string) {
 
 // availabilityStatusMatches returns true if both the source status and the target status match, which implies that the
 // current source should be checked for an availability status. In the case of having an "unavailable" target status,
-// the empty string is also considered as "unavailable".
+// the empty string is also considered as "unavailable", and the "in_progress" one too.
 func availabilityStatusMatches(sourceStatus string, targetStatus string) bool {
 	if targetStatus == unavailableStatus {
-		return sourceStatus == targetStatus || sourceStatus == ""
+		return sourceStatus == targetStatus || sourceStatus == "" || sourceStatus == "in_progress"
 	}
 
 	return sourceStatus == targetStatus

--- a/main_test.go
+++ b/main_test.go
@@ -12,7 +12,7 @@ const (
 
 // TestAvailabilityStatusMatches tests if the function under test returns "true" only when the source status matches
 // the target status. It also tests that a "true" is returned when the target status is "unavailable" and the source's
-// status is empty.
+// status is empty or the source's status is "in_progress".
 func TestAvailabilityStatusMatches(t *testing.T) {
 	testData := []struct {
 		SourceStatus        string
@@ -24,7 +24,7 @@ func TestAvailabilityStatusMatches(t *testing.T) {
 		{partiallyAvailableStatus, availableStatus, false},
 		{unavailableStatus, availableStatus, false},
 		{availableStatus, unavailableStatus, false},
-		{inProgressStatus, unavailableStatus, false},
+		{inProgressStatus, unavailableStatus, true},
 		{partiallyAvailableStatus, unavailableStatus, false},
 		{unavailableStatus, unavailableStatus, true},
 		{"", unavailableStatus, true},


### PR DESCRIPTION
The "availability_status" column of the sources API database is
defaulting to "in_progress", so any sources that are listed in that
status they should be checked too.

## Links
[[RHCLOUD-19948]](https://issues.redhat.com/browse/RHCLOUD-19948)