### PR TITLE
[RHCLOUD-21150] Use Red Hat IT's custom sonar scanner container image

### DIFF
--- a/scripts/scanner/scan_code.bash
+++ b/scripts/scanner/scan_code.bash
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+#
+# Bash safety options:
+#   - e is for exiting immediately when a command exits with a non-zero status.
+#   - u is for treating unset variables as an error when substituting.
+#   - x is for printing all the commands as they're executed.
+#   - o pipefail is for taking into account the exit status of the commands that run on pipelines.
+#
+set -euxo pipefail
+
+#
+# Copy the repository contents so we don't have to deal with changing permissions on the mounted volume.
+#
+source_dir=$(mktemp --directory)
+cp --recursive "/repository" "${source_dir}"
+
+#
+# Run the sonar scanner.
+#
+
+sonar-scanner \
+  -Dsonar.exclusions="**/*.sql" \
+  -Dsonar.projectBaseDir="${source_dir}/repository" \
+  -Dsonar.projectKey="${SONAR_PROJECT_KEY}" \
+  -Dsonar.projectVersion="${SONAR_PROJECT_VERSION}" \
+  -Dsonar.pullrequest.base="main" \
+  -Dsonar.pullrequest.branch="${SONAR_PULL_REQUEST_BRANCH}" \
+  -Dsonar.pullrequest.key="${SONAR_PULL_REQUEST_KEY}" \
+  -Dsonar.sources="${source_dir}/repository"
+
+#
+# Clean the repository directory.
+#
+rm --force --recursive "${source_dir}"

--- a/scripts/sonarqube.bash
+++ b/scripts/sonarqube.bash
@@ -1,92 +1,42 @@
 #!/bin/bash
 
 #
-# This script runs SonarQube's scanner on the project. As our SonarQube instance
-# uses a self-signed certificate, before running the scanner a keystore
-# containing RH IT's certificate is created. After that, the scanner is
-# downloaded and run.
+# Bash safety options:
+#   - e is for exiting immediately when a command exits with a non-zero status.
+#   - u is for treating unset variables as an error when substituting.
+#   - x is for printing all the commands as they're executed.
+#   - o pipefail is for taking into account the exit status of the commands that run on pipelines.
 #
-
 set -euxo pipefail
 
-readonly sonarqube_dir="$PWD/sonarqube"
-readonly sonarqube_certs_dir="$sonarqube_dir/certs"
-readonly sonarqube_download_dir="$sonarqube_dir/download"
-readonly sonarqube_extract_dir="$sonarqube_dir/extract"
-readonly sonarqube_store_dir="$sonarqube_dir/store"
-
-readonly rh_it_keystore_file="$sonarqube_store_dir/RH-IT-Root-CA.keystore"
-readonly rh_it_keystore_pass="redhat"
-readonly rh_it_root_ca_file="$sonarqube_certs_dir/RH-IT-Root-CA.crt"
-
-mkdir "$sonarqube_dir"
-mkdir "$sonarqube_certs_dir"
-mkdir "$sonarqube_download_dir"
-mkdir "$sonarqube_extract_dir"
-mkdir "$sonarqube_store_dir"
-
 #
-# To make SonarQube's scanner trust the SonarQube instance with the custom
-# certificate, a keystore containing Red Hat IT's root certificate must be
-# created, to then pass it to the scanner.
+# Get the commit SHA to give the scanner a unique "project version" setting.
 #
-curl --output "$rh_it_root_ca_file" --insecure "$RH_IT_ROOT_CA_CERT_URL"
-
-# The JAVA_HOME variable is not set by default. Even though it is usually an
-# environment variable, we write it in lowercase because in this case we only
-# use it in this script.
-java_home="/usr/lib/jvm/jre-1.8.0"
-
-"$java_home"/bin/keytool \
-  -alias "RH-IT-Root-CA" \
-  -file "$rh_it_root_ca_file" \
-  -import \
-  -keystore "$rh_it_keystore_file" \
-  -noprompt \
-  -storepass "$rh_it_keystore_pass"
-
-#
-# Download and extract sonnarcube-cli.
-#
-if [[ "$OSTYPE" == "darwin"* ]]; then
-  readonly sonar_scanner_os="macosx"
-else
-  readonly sonar_scanner_os="linux"
-fi
-
-readonly sonar_scanner_cli_version="4.7.0.2747"
-readonly sonar_scanner_name="sonar-scanner-$sonar_scanner_cli_version-$sonar_scanner_os"
-readonly sonar_scanner_zipped_file="$sonarqube_download_dir/$sonar_scanner_name.zip"
-
-curl --output "$sonar_scanner_zipped_file" "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-4.7.0.2747-linux.zip"
-unzip -d "$sonarqube_extract_dir" "$sonar_scanner_zipped_file"
-
-#
-# Export the path to the binary.
-#
-export PATH="$sonarqube_extract_dir/$sonar_scanner_name/bin:$PATH"
-
-# Get the commit SHA in very short format for the project version.
 commit_short=$(git rev-parse --short=7 HEAD)
 
 #
-# Run the sonar-scanner by specifying the previously created keystore.
+# Get the current directory since it represents the project's root directory.
 #
-export SONAR_SCANNER_OPTS="-Djavax.net.ssl.trustStore=$rh_it_keystore_file -Djavax.net.ssl.trustStorePassword=$rh_it_keystore_pass"
-# The Jenkins pipeline inject the pull request ID with the lowercase variable,
-# so the shellcheck rule must be disabled to avoid any issues.
-# shellcheck disable=SC2154
-sonar-scanner \
-  -Dsonar.host.url="$SONARQUBE_REPORT_URL" \
-  -Dsonar.login="$SONARQUBE_TOKEN" \
-  -Dsonar.projectKey=console.redhat.com:sources-monitor-go \
-  -Dsonar.projectVersion="$commit_short" \
-  -Dsonar.pullrequest.base="main" \
-  -Dsonar.pullrequest.branch="$GIT_BRANCH" \
-  -Dsonar.pullrequest.key="$ghprbPullId" \
-  -Dsonar.sources=.
+current_directory=$(pwd)
 
-# Need to make a dummy results file to make tests pass
+#
+# Run the Sonar Scanner in a container. The "repository" directory is just the source code, and we mount it to be able
+# to scan the source code.
+#
+docker run  \
+  --rm \
+  --volume "${current_directory}":/repository \
+  --env SONAR_LOGIN="${SONARQUBE_TOKEN}" \
+  --env SONAR_HOST_URL="${SONARQUBE_REPORT_URL}" \
+  --env SONAR_PROJECT_KEY="console.redhat.com:sources-monitor-go" \
+  --env SONAR_PROJECT_VERSION="${commit_short}" \
+  --env SONAR_PULL_REQUEST_BASE="main" \
+  --env SONAR_PULL_REQUEST_BRANCH="${GIT_BRANCH}" \
+  --env SONAR_PULL_REQUEST_KEY="${ghprbPullId}" \
+  images.paas.redhat.com/alm/sonar-scanner:latest \
+  bash /repository/scripts/scanner/scan_code.bash
+
+# Need to make a dummy results file to make tests pass.
 mkdir -p artifacts
 cat << EOF > artifacts/junit-dummy.xml
 <testsuite tests="1">


### PR DESCRIPTION
The IT team has built a custom image which already has the keystore generated with Red Hat's IT custom certificate in it. This simplifies the scan process since we only have to mount the code in the container and run the scanner, instead of having to create the keystore ourselves and having to download the scanner every time the pipeline ran.

## Links

[[RHCLOUD-21150]](https://issues.redhat.com/browse/RHCLOUD-21150)