### PR TITLE
[RHCLOUD-29368]  added KubeLinter check 'run-as-non-root' in the Sources Monitor deploymen

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,6 +16,9 @@ objects:
       restartPolicy: Never
       startingDeadlineSeconds: 30
       podSpec:
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
         image: ${IMAGE}:${IMAGE_TAG}
         command:
         - /sources-monitor-go
@@ -47,6 +50,9 @@ objects:
       restartPolicy: Never
       startingDeadlineSeconds: 30
       podSpec:
+        securityContext:
+          runAsUser: 1000
+          runAsNonRoot: true
         image: ${IMAGE}:${IMAGE_TAG}
         command:
         - /sources-monitor-go


### PR DESCRIPTION
the `deployment_validation_operator_run_as_non_root` is failing ([dashboard](https://grafana.app-sre.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=crcp01ue1&var-namespace=sources-prod)) so this PR adds the security context to solve this requirement

JIRA: [RHCLOUD-29368](https://issues.redhat.com/browse/RHCLOUD-29368)