### PR TITLE
[RHCLOUD-32442] Update Go to baseline version 1.18

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - uses: Jerome1337/gofmt-action@v1.0.4
 
   govet:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - run: |
           go vet ./...
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
@@ -49,6 +49,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.17"
+          go-version: "1.18"
       - run: |
           go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/RedHatInsights/sources-monitor-go
 
-go 1.17
+go 1.18


### PR DESCRIPTION
jira [RHCLOUD-32442](https://issues.redhat.com/browse/RHCLOUD-32442)