### PR TITLE
[RHCLOUD-33773] update github actions (checkout, setup-go, golangci-lint-action, gofmt-action) to the latest version

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -9,18 +9,18 @@ jobs:
     name: go fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.18"
-      - uses: Jerome1337/gofmt-action@v1.0.4
+      - uses: Jerome1337/gofmt-action@v1.0.5
 
   govet:
     name: go vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.18"
       - run: |
@@ -30,24 +30,23 @@ jobs:
     name: golangci-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.18"
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v6
         with:
           version: latest
           only-new-issues: true
-          skip-go-installation: true
           args: --enable gci,bodyclose,forcetypeassert,misspell
 
   gotest:
     name: go test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.18"
       - run: |


### PR DESCRIPTION
[RHCLOUD-33773](https://issues.redhat.com/browse/RHCLOUD-33773)

bump github actions to the latest versions

- [checkout](https://github.com/actions/checkout)
- [setup-go](https://github.com/actions/setup-go)
- [golangci-lint-action](https://github.com/golangci/golangci-lint-action)
- [gofmt-action](https://github.com/Jerome1337/gofmt-action)