### PR TITLE
RHCLOUD-38735 | feature: skip empty Sources for avaiability checks

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -111,7 +111,7 @@ parameters:
 - description: Skips fetching sources that are considered empty and for which availability checks are unnecessary to run.
   displayName: Skip fetching empty sources.
   name: SKIP_EMPTY_SOURCES
-  value: "false",
+  value: "false"
   required: true
 - description: Scheme to use for the Sources service URL.
   displayName: Sources Service Scheme

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -25,6 +25,8 @@ objects:
         - -status
         - available
         env:
+        - name: SKIP_EMPTY_SOURCES
+          value: ${SKIP_EMPTY_SOURCES}
         - name: SOURCES_SCHEME
           value: ${SOURCES_SCHEME}
         - name: SOURCES_HOST
@@ -59,6 +61,8 @@ objects:
         - -status
         - unavailable
         env:
+        - name: SKIP_EMPTY_SOURCES
+          value: ${SKIP_EMPTY_SOURCES}
         - name: SOURCES_SCHEME
           value: ${SOURCES_SCHEME}
         - name: SOURCES_HOST
@@ -104,6 +108,11 @@ parameters:
   displayName: Schedule for Unavailable Sources
   name: SCHEDULE_UNAVAILABLE
   value: "15,45 */1 * * *"
+- description: Skips fetching sources that are considered empty and for which availability checks are unnecessary to run.
+  displayName: Skip fetching empty sources.
+  name: SKIP_EMPTY_SOURCES
+  value: "false",
+  required: true
 - description: Scheme to use for the Sources service URL.
   displayName: Sources Service Scheme
   name: SOURCES_SCHEME

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -41,7 +42,7 @@ func main() {
 	flag.Parse()
 
 	// Check whether we need to skip empty sources when fetching them or not.
-	skipEmptySources := os.Getenv("SKIP_EMPTY_SOURCES") != "true"
+	skipEmptySources := strings.ToLower(os.Getenv("SKIP_EMPTY_SOURCES")) != "true"
 
 	if psk == "" {
 		log.Fatalf("Need PSK to run availability checks.")


### PR DESCRIPTION
Avoids fetching sources that do not require an availability status check.

## Jira ticket
[[RHCLOUD-38735]](https://issues.redhat.com/browse/RHCLOUD-38735)