### PR TITLE
RHCLOUD-38735 | fix: empty sources are not skipped

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 	flag.Parse()
 
 	// Check whether we need to skip empty sources when fetching them or not.
-	skipEmptySources := strings.ToLower(os.Getenv("SKIP_EMPTY_SOURCES")) != "true"
+	skipEmptySources := strings.ToLower(os.Getenv("SKIP_EMPTY_SOURCES")) == "true"
 
 	if psk == "" {
 		log.Fatalf("Need PSK to run availability checks.")


### PR DESCRIPTION
The condition to set the "should we skip empty sources" variable was
inverted.

## Jira ticket
[[RHCLOUD-38735]](https://issues.redhat.com/browse/RHCLOUD-38735)