### PR TITLE
[RHCLOUD-41106] Bump Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN microdnf install --assumeyes go
 
 ARG GOARCH=amd64
 ARG GOOS=linux
-ARG GOTOOLCHAIN=go1.24.3
 
 COPY . .
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/RedHatInsights/sources-monitor-go
 
-go 1.24.3
+go 1.24.4


### PR DESCRIPTION
## Jira issues

- https://issues.redhat.com/browse/RHCLOUD-41106
- https://issues.redhat.com/browse/RHCLOUD-40848

## Description

Bump Go version, see first ticket.
