### PR TITLE
sources-monitor-go can segv if http call to availability check endpoint fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -148,6 +148,7 @@ func checkAvailability(id, tenant, orgId string, skipEmptySources bool) {
 			log.Printf("Request status code: %v", resp.StatusCode)
 		}
 	}
+
 	if resp != nil {
 		defer resp.Body.Close()
 	}

--- a/main.go
+++ b/main.go
@@ -148,7 +148,9 @@ func checkAvailability(id, tenant, orgId string, skipEmptySources bool) {
 			log.Printf("Request status code: %v", resp.StatusCode)
 		}
 	}
-	defer resp.Body.Close()
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	// consume one value from the choke so another waiting routine can use it.
 	<-choke


### PR DESCRIPTION
Fixed the segv by wrapping in a nil check

Now if the resp is nil it will skip the defer 
if not nil we close the body 


https://issues.redhat.com/browse/RHCLOUD-44727