### PR TITLE
chore(deps): update Go stdlib from 1.24 to 1.26.6

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.3"
+          go-version: "1.26.6"
       - uses: Jerome1337/gofmt-action@v1.0.5
 
   govet:
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.3"
+          go-version: "1.26.6"
       - run: |
           go vet ./...
 
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.3"
+          go-version: "1.26.6"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
@@ -48,6 +48,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.24.3"
+          go-version: "1.26.6"
       - run: |
           go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/RedHatInsights/sources-monitor-go
 
-go 1.24.4
+go 1.26.6


### PR DESCRIPTION
## Summary
- Update Go version from 1.24.4 to 1.26.6 in `go.mod`
- Update Go version from 1.24.3 to 1.26.6 in all 4 CI workflow jobs (`.github/workflows/actions.yml`)

## Test plan
- [ ] CI passes with Go 1.26.6 (fmt, vet, lint, test)
- [ ] `go mod tidy` run after merge to ensure `go.sum` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)